### PR TITLE
Issue 1 - escape reserved characters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/src/sitegen/mod.rs
+++ b/src/sitegen/mod.rs
@@ -206,7 +206,8 @@ impl SiteGen {
                 // These are pages that do not belong to any group.
                 // They are generated without any grouping or prev/next links.
                 for page in pages {
-                    page.generate(None, None, &self.tags)?;
+                    page.generate(None, None, &self.tags);
+                    page.write()?;
                 }
                 continue;
             }
@@ -232,8 +233,9 @@ impl SiteGen {
                     None
                 };
 
-                // Generate the page (this will write the HTML file to disk)
-                pages[i].generate(prev, next, &self.tags)?;
+                // Generate the page and write the HTML file to disk
+                pages[i].generate(prev, next, &self.tags);
+                pages[i].write()?;
             }
         }
         Ok(())

--- a/src/sitegen/page.rs
+++ b/src/sitegen/page.rs
@@ -125,7 +125,7 @@ impl Page {
         self.metadata.clone()
     }
 
-    pub fn generate(&mut self, prev: Option<Metadata>, next: Option<Metadata>, tags: &BTreeMap<String, TagPage>) -> Result<(), anyhow::Error> {
+    pub fn generate(&mut self, prev: Option<Metadata>, next: Option<Metadata>, tags: &BTreeMap<String, TagPage>) {
         println!("generating page '{}'", &self.metadata.path);
 
         // Process { include "<path>" } blocks
@@ -215,8 +215,10 @@ impl Page {
 
         // Rewrite all links and references to be relative to this document
         self.contents = super::rewrite_local_links(&self.contents, &self.output_path, &self.root_path);
+    }
 
-        // Write output HTML file
+    pub fn write(&self) -> Result<(), anyhow::Error> {
+        // Write the processed contents to the output HTML file
         write(&self.output_path, &self.contents)
             .with_context(|| format!("Unable to write output HTML file '{}'", &self.output_path.display()))
     }


### PR DESCRIPTION
Escapes reserved HTML characters '<' and '>' with HTML entities when present in the title and/or author metadata.